### PR TITLE
Specify host_post to avoid perpetual diffs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -247,6 +247,7 @@ resource "kubernetes_daemonset" "this" {
           name              = "aws-node-termination-handler"
           port {
             container_port = 9092
+            host_port      = 9092
             name           = "prometheus"
             protocol       = "TCP"
           }


### PR DESCRIPTION
Thanks for providing this useful module.   I'm on EKS 1.17 and when I apply this module the state doesn't converge.   Running `terraform plan` after a successful `terraform apply` shows a diff:

```
 ~ port {
       container_port = 9092
     - host_port      = 9092 -> null
       name           = "prometheus"
       protocol       = "TCP"
   }
```

Per the TF [deployment object](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment) docs:
> If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.

This is easily fixed by specifying a matching `host_port` value of 9092.