### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -256,11 +256,11 @@ resource "kubernetes_daemonset" "this" {
             protocol       = "TCP"
           }
           resources {
-            limits {
+            limits = {
               cpu    = "100m"
               memory = "128Mi"
             }
-            requests {
+            requests = {
               cpu    = "50m"
               memory = "64Mi"
             }


### PR DESCRIPTION
Fix for terraform v1.0.8

Otherwise Terraform prints following error:
```
$ terraform plan
Releasing state lock. This may take a few moments...
╷
│ Error: Unsupported block type
│
│   on .terraform/modules/aws-node-termination-handler/main.tf line 255, in resource "kubernetes_daemonset" "this":
│  255:             limits {
│
│ Blocks of type "limits" are not expected here. Did you mean to define argument "limits"? If so, use the equals sign to assign it a value.
╵
╷
│ Error: Unsupported block type
│
│   on .terraform/modules/aws-node-termination-handler/main.tf line 259, in resource "kubernetes_daemonset" "this":
│  259:             requests {
│
│ Blocks of type "requests" are not expected here. Did you mean to define argument "requests"? If so, use the equals sign to assign it a value.
```
